### PR TITLE
Fix the binary name for `pull-requester` in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="Jonathan Wright <jon@than.io>" \
   org.opencontainers.image.authors="Jonathan Wright <jon@than.io>" \
   org.opencontainers.image.vendor="n3t.uk"
 
-COPY pull-requester /go/bin/pull
+COPY pull-requester /go/bin/pull-requester
 
 ENTRYPOINT ["/go/bin/pull-requester"]
 CMD ["run"]

--- a/action.yaml
+++ b/action.yaml
@@ -6,7 +6,7 @@ description: |-
 
 runs:
   using: docker
-  image: ghcr.io/n3tuk/pull-requester
+  image: docker://ghcr.io/n3tuk/pull-requester
   args:
     - run
 


### PR DESCRIPTION
Fix the name of the binary for `pull-requester` in the `Dockerfile,` which was incorrectly truncated.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [ ] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
