### PR TITLE
Add automation for tagging the GitHub Action

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -19,9 +19,28 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Draft the release
+        id: drafter
         uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           config-name: release-drafter.yaml
           disable-autolabeler: true
+
+      - name: Prepare the published tag reference
+        run: |-
+          sed -i 's|\(scripts/run\) \(v[0-9\.]\+\)$|\1 ${{ steps.drafter.output.id }}|' action.yaml
+
+      - name: Commit the published tag update
+        run: |-
+          if git diff --exit-code --quiet action.yaml
+            echo "No changes to action.yaml need to be committed for the release."
+            exit 0
+          fi
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add action.yaml
+          git commit --no-verify \
+             -m "Update tag in GitHub Action to prepare for release" \
+             -m "Update the published tag to ${{ steps.drafter.output.id }} to prepare the GitHub Action for release."
+          git push

--- a/.github/workflows/go-releaser.yaml
+++ b/.github/workflows/go-releaser.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Update the tags
+      - name: Fetch the tags
         run: git fetch --force --tags
 
       - name: Set up Go
@@ -44,6 +44,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
+        id: releaser
         uses: goreleaser/goreleaser-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -52,14 +53,46 @@ jobs:
           version: latest
           args: release --clean
 
-  update-tags:
-    name: Update Major/Minor Tags
+  update-documentation:
+    name: Update the Documentation
     runs-on: ubuntu-latest
+    needs:
+      - goreleaser
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
 
-      - name: Update the tags
+      - name: Fetch the tags
+        run: git fetch --force --tags
+
+      - name: Update the documentation tag reference
+        run: |-
+          sed -i 's|\(uses: n3tuk/pull-requester\)@\([v[0-9\.]\+\)$|\1@${{ github.ref_name }}|' README.md
+
+      - name: Commit the documentation tag update
+        run: |-
+          if git diff --exit-code --quiet README.md
+            echo "No changes to README.md need to be committed due to a release."
+            exit 0
+          fi
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add README.md
+          git commit --no-verify \
+             -m "Update the GitHub Action tag to ${{ github.ref_name }} in README" \
+             -m "Update the version tag for the GitHub Action in the README to ${{ steps.drafter.outputs.id }}\nto account for the latest release."
+          git push
+
+  update-tags:
+    name: Update Major/Minor Tags
+    runs-on: ubuntu-latest
+    needs:
+      - goreleaser
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Fetch the tags
         run: git fetch --force --tags
 
       - name: Force update the major tag

--- a/.github/workflows/pull-requester.yaml
+++ b/.github/workflows/pull-requester.yaml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   issues: write
   pull-requests: write
 
@@ -35,4 +36,4 @@ jobs:
       - name: Pull Requester
         # Target main here as it's easier than trying to deal with future
         # versions that this pull request will become
-        uses: n3tuk/action-pull-requester@main
+        uses: n3tuk/action-pull-requester@v1

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,11 @@ coverage/*
 .codeql
 codeql.sarif
 
-# Ignore the build output
+# Ignore the build output and any pre-built downloads
 bin/*
 dist/*
+scripts/pull-requester*
+scripts/LICENSE
 
 # Ignore taskfile processing directory
 .task

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,11 @@ changelog:
   skip: true
 snapshot:
   name_template: "{{ incpatch .Version }}~g{{ .ShortCommit }}{{ if .IsGitDirty }}-d{{ .Now.Format \"02-t150405\" }}{{ end }}"
+checksum:
+  name_template: "{{ .ProjectName }}-{{ .Version }}-checksums.txt"
+
 builds:
+
   - id: pull-requester
     main: main.go
     binary: pull-requester
@@ -29,7 +33,9 @@ builds:
     targets:
       - linux_amd64
       - linux_arm64
+
 archives:
+
   - id: default
     name_template: >-
       {{ .ProjectName }}-
@@ -40,11 +46,10 @@ archives:
     rlcp: true
     files:
       - LICENSE
-checksum:
-  name_template: "{{ .ProjectName }}-{{ .Version }}-checksums.txt"
 
 # Create images for both amd64 and arm64 to give it the widest possible support
 dockers:
+
   - id: pull-requester-amd64
     goarch: amd64
     image_templates:
@@ -56,6 +61,7 @@ dockers:
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
+
   - id: pull-requester-arm64
     goarch: arm64
     image_templates:
@@ -72,37 +78,20 @@ dockers:
 # called, including as the main branch, both short and long commit IDs, and each of
 # Major, Major/Minor, and Major/Minor/Patch versions being tagged
 docker_manifests:
+
   - name_template: ghcr.io/n3tuk/pull-requester:latest
     use: docker
     image_templates:
       - ghcr.io/n3tuk/pull-requester:{{ .Version }}-amd64
       - ghcr.io/n3tuk/pull-requester:{{ .Version }}-arm64
-  - name_template: ghcr.io/n3tuk/pull-requester:main
+
+  - name_template: ghcr.io/n3tuk/pull-requester:{{ .Version }}
     use: docker
     image_templates:
       - ghcr.io/n3tuk/pull-requester:{{ .Version }}-amd64
       - ghcr.io/n3tuk/pull-requester:{{ .Version }}-arm64
-  - name_template: ghcr.io/n3tuk/pull-requester:{{ .FullCommit }}
-    use: docker
-    image_templates:
-      - ghcr.io/n3tuk/pull-requester:{{ .Version }}-amd64
-      - ghcr.io/n3tuk/pull-requester:{{ .Version }}-arm64
+
   - name_template: ghcr.io/n3tuk/pull-requester:{{ .ShortCommit }}
-    use: docker
-    image_templates:
-      - ghcr.io/n3tuk/pull-requester:{{ .Version }}-amd64
-      - ghcr.io/n3tuk/pull-requester:{{ .Version }}-arm64
-  - name_template: ghcr.io/n3tuk/pull-requester:v{{ .Major }}.{{ .Minor }}.{{ .Patch}}
-    use: docker
-    image_templates:
-      - ghcr.io/n3tuk/pull-requester:{{ .Version }}-amd64
-      - ghcr.io/n3tuk/pull-requester:{{ .Version }}-arm64
-  - name_template: ghcr.io/n3tuk/pull-requester:v{{ .Major }}.{{ .Minor }}
-    use: docker
-    image_templates:
-      - ghcr.io/n3tuk/pull-requester:{{ .Version }}-amd64
-      - ghcr.io/n3tuk/pull-requester:{{ .Version }}-arm64
-  - name_template: ghcr.io/n3tuk/pull-requester:v{{ .Major }}
     use: docker
     image_templates:
       - ghcr.io/n3tuk/pull-requester:{{ .Version }}-amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/distroless/base:latest
 LABEL maintainer="Jonathan Wright <jon@than.io>" \
   org.opencontainers.image.url="https://github.com/n3tuk/action-pull-requester" \
-  org.opencontainers.image.source="https://github.com/n3tuk/action-pull-requester/blob/Dockerfile" \
+  org.opencontainers.image.source="https://github.com/n3tuk/action-pull-requester" \
   org.opencontainers.image.title="pull-requester" \
   org.opencontainers.image.description="A GitHub Action for checking pull requests" \
   org.opencontainers.image.authors="Jonathan Wright <jon@than.io>" \

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   issues: write
   pull-requests: write
 
@@ -50,3 +51,8 @@ jobs:
       - name: Pull Requester
         uses: n3tuk/action-pull-requester@v1.0.0
 ```
+
+> **Note**:
+> Do **not** use the `main` branch as a tag for the GitHub Action, as the
+> container for the GitHub Action builds and releases on tagging, and the
+> preparation for that is on merges to the `main` branch.

--- a/action.yaml
+++ b/action.yaml
@@ -5,10 +5,10 @@ description: |-
   for the n3tuk Organisation.
 
 runs:
-  using: docker
-  image: docker://ghcr.io/n3tuk/pull-requester
-  args:
-    - run
+  using: composite
+  steps:
+    - run: ${{ github.action_path }}/scripts/run v1.0.0
+      shell: bash
 
 branding:
   icon: user-check

--- a/scripts/run
+++ b/scripts/run
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -ueo pipefail
+
+TAG=${1:-latest}
+VERSION=${TAG#v}
+
+curl --silent --location \
+  --header "Authorization: Bearer $GITHUB_TOKEN" \
+  --output $GITHUB_ACTION_PATH/scripts/pull-requester.tar.gz \
+  https://github.com/n3tuk/action-pull-requester/releases/download/v${VERSION}/pull-requester-${VERSION}-linux-amd64.tar.gz
+
+tar xzf \
+  $GITHUB_ACTION_PATH/scripts/pull-requester.tar.gz \
+  -C $GITHUB_ACTION_PATH/scripts/
+
+$GITHUB_ACTION_PATH/scripts/pull-requester run


### PR DESCRIPTION
Add additional automation for the tagging of the GitHub Action, including both for the `README.md` on tagging of the archive for release, as well as for the `action.yaml` when changes are made to the `main` branch in preparation for release.

This will mean that the `main` branch may not always be able to launch a run, as the `action.yaml` may point to a container that has not been built or released yet.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
