### PR TITLE
Fix scripting syntax errors in GitHub Workflows

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -34,6 +34,7 @@ jobs:
       - name: Commit the published tag update
         run: |-
           if git diff --exit-code --quiet action.yaml
+          then
             echo "No changes to action.yaml need to be committed for the release."
             exit 0
           fi

--- a/.github/workflows/go-releaser.yaml
+++ b/.github/workflows/go-releaser.yaml
@@ -72,6 +72,7 @@ jobs:
       - name: Commit the documentation tag update
         run: |-
           if git diff --exit-code --quiet README.md
+          then
             echo "No changes to README.md need to be committed due to a release."
             exit 0
           fi


### PR DESCRIPTION
Fix the missing then token in the scripts for the commit processing.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
