### PR TITLE
Remove the `secrets` context in `action.yaml` as not supported

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -11,7 +11,7 @@ runs:
     - name: Fetch the pull-requester artifact
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ secrets.github_token || github.token }}
+        GITHUB_TOKEN: ${{ github.token }}
         # Both github.action_repository and .action_ref are not available inside
         # the run: statement, but they are available under env: so set them here
         # so they can be accessed as normal environment variable under the
@@ -27,7 +27,7 @@ runs:
     - name: Run pull-requester against the pull request
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ secrets.github_token || github.token }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: |-
         ${{ github.action_path }}/bin/pull-requester run
 


### PR DESCRIPTION
Remove the `secrets` context in the `action.yaml` configuration as it's not supported here - they should be passed in via `inputs` instead.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
