### PR TITLE
Add support for checking pull request labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ jobs:
 
 ## Inputs
 
-| Name | Description | Required | Default |
-| :--- | :---------- | :------: | :------ |
-| `title-minimum` | The minimum number of characters that a title should contain | `false` | `25` |
+| Name             | Description                                                             | Required | Default |
+| :--------------- | :---------------------------------------------------------------------- | :------: | :------ |
+| `title-minimum`  | The minimum number of characters that a title should contain            | `false`  | `25`    |
+| `label-prefixes` | A comma-separated list of label prefixes to check for on a pull request | `false`  | `''`    |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ jobs:
 
 ## Inputs
 
-| Name             | Description                                                             | Required | Default |
-| :--------------- | :---------------------------------------------------------------------- | :------: | :------ |
-| `title-minimum`  | The minimum number of characters that a title should contain            | `false`  | `25`    |
-| `label-prefixes` | A comma-separated list of label prefixes to check for on a pull request | `false`  | `''`    |
+| Name                 | Description                                                             | Required | Type     | Default |
+| :------------------- | :---------------------------------------------------------------------- | :------: | :------- | :------ |
+| `title-minimum`      | The minimum number of characters that a title should contain            | `false`  | `int`    | `25`    |
+| `label-prefixes`     | A comma-separated list of label prefixes to check for on a pull request | `false`  | `string` | `''`    |
+| `label-prefixes-any` | Set that any label prefix can match to pass, rather than all            | `false`  | `bool`   | `false' |

--- a/action.yaml
+++ b/action.yaml
@@ -8,7 +8,11 @@ inputs:
   title-minimum:
     description: The minimum number of characters that a title should contain
     required: false
-    default: 25
+    default: '25'
+  label-prefixes:
+    description: A comma-separated list of label prefixes to check for on a pull request
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -36,7 +40,8 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
       run: |-
         ${{ github.action_path }}/bin/pull-requester run \
-          --title-minimum ${{ inputs.title-minimum }}
+          --title-minimum ${{ inputs.title-minimum }} \
+          --label-prefixes ${{ inputs.label-prefixes }}
 
 branding:
   icon: user-check

--- a/action.yaml
+++ b/action.yaml
@@ -13,6 +13,10 @@ inputs:
     description: A comma-separated list of label prefixes to check for on a pull request
     required: false
     default: ''
+  label-prefixes-any:
+    description: Set that any label prefix can match to pass, rather than all
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -40,8 +44,9 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
       run: |-
         ${{ github.action_path }}/bin/pull-requester run \
-          --title-minimum ${{ inputs.title-minimum }} \
-          --label-prefixes ${{ inputs.label-prefixes }}
+          --title-minimum=${{ inputs.title-minimum }} \
+          --label-prefixes=${{ inputs.label-prefixes }}
+          --label-prefixes-any=${{ inputs.label-prefixes-any }}
 
 branding:
   icon: user-check

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,7 +16,8 @@ var (
 
 	dryRun bool
 
-	titleMinimum int = 25
+	titleMinimum  int = 25
+	labelPrefixes string
 
 	// runCmd represents the run command
 	runCmd = &cobra.Command{
@@ -32,12 +33,14 @@ func init() {
 	runCmd.Flags().StringVarP(&repository, "repository", "r", "action-pull-requester", "The name of the repository to check")
 	runCmd.Flags().IntVar(&number, "number", 0, "The number of the pull request to check")
 	runCmd.Flags().IntVar(&titleMinimum, "title-minimum", titleMinimum, "The minimum number of characters a title should contain")
+	runCmd.Flags().StringVar(&labelPrefixes, "label-prefixes", "", "A comma-separated list of label prefixes to check for on a pull request")
 	rootCmd.AddCommand(runCmd)
 }
 
 func RunChecks(cmd *cobra.Command, args []string) error {
 	options := &action.Options{
-		TitleMinimum: titleMinimum,
+		TitleMinimum:  titleMinimum,
+		LabelPrefixes: labelPrefixes,
 	}
 
 	pr, err := github.NewPullRequest(logger, owner, repository, number)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,8 +16,9 @@ var (
 
 	dryRun bool
 
-	titleMinimum  int = 25
-	labelPrefixes string
+	titleMinimum     int = 25
+	labelPrefixes    string
+	labelPrefixesAny bool
 
 	// runCmd represents the run command
 	runCmd = &cobra.Command{
@@ -34,13 +35,15 @@ func init() {
 	runCmd.Flags().IntVar(&number, "number", 0, "The number of the pull request to check")
 	runCmd.Flags().IntVar(&titleMinimum, "title-minimum", titleMinimum, "The minimum number of characters a title should contain")
 	runCmd.Flags().StringVar(&labelPrefixes, "label-prefixes", "", "A comma-separated list of label prefixes to check for on a pull request")
+	runCmd.Flags().BoolVar(&labelPrefixesAny, "label-prefixes-any", false, "Set that any label prefix can match to pass, rather than all")
 	rootCmd.AddCommand(runCmd)
 }
 
 func RunChecks(cmd *cobra.Command, args []string) error {
 	options := &action.Options{
-		TitleMinimum:  titleMinimum,
-		LabelPrefixes: labelPrefixes,
+		TitleMinimum:     titleMinimum,
+		LabelPrefixes:    labelPrefixes,
+		LabelPrefixesAny: labelPrefixesAny,
 	}
 
 	pr, err := github.NewPullRequest(logger, owner, repository, number)

--- a/internal/action/check_labels.go
+++ b/internal/action/check_labels.go
@@ -1,0 +1,66 @@
+package action
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/go-github/v52/github"
+	"github.com/sirupsen/logrus"
+)
+
+// Define an Interface which maps to the GetLabels function on the type so that
+// we can simplify the requirements of the value passed and improve testability
+type PullRequestLabels interface {
+	GetLabels() []*github.Label
+}
+
+// Check the labels of the pull request to validate that the prefixes requested
+// have been attached, and return an error if it is not
+func CheckLabels(log *logrus.Logger, pull PullRequestLabels, prefixes []string, any bool) error {
+	var attached, missing []string
+
+	labels := pull.GetLabels()
+	for _, label := range labels {
+		attached = append(attached, *label.Name)
+	}
+
+	log.
+		WithFields(logrus.Fields{
+			"attached": strings.Join(attached, ","),
+			"prefixes": strings.Join(prefixes, ","),
+		}).
+		Debug("checking the labels")
+
+	for _, prefix := range prefixes {
+		found := false
+
+		log.
+			WithFields(logrus.Fields{
+				"prefix": prefix,
+			}).
+			Debug("checking for label prefix")
+
+		for _, label := range attached {
+			if strings.HasPrefix(label, prefix) {
+				if any {
+					return nil // quick exit
+				}
+
+				found = true
+			}
+		}
+
+		if !found {
+			missing = append(missing, prefix)
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("labels with the prefix(es) %s have not been found", strings.Join(missing, ","))
+	}
+
+	log.
+		Info("the pull request label check has passed")
+
+	return nil
+}

--- a/internal/action/check_labels_test.go
+++ b/internal/action/check_labels_test.go
@@ -1,0 +1,126 @@
+package action_test
+
+import (
+	"testing"
+
+	"github.com/n3tuk/action-pull-requester/internal/action"
+
+	"github.com/google/go-github/v52/github"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+// Define the structure of the table for TestCheckLabels, with the expected
+// input, the test for the length, and if the CheckLabels() function should pass
+// or fail the test
+type CheckLabelsTest struct {
+	Name             string
+	Labels           []*github.Label
+	RequiredPrefixes []string
+	AnyPrefix        bool
+	Pass             bool
+}
+
+var (
+	// Pre-create the strings for the names as they must be passed and pointers
+	nameTestOne     = "test/one"
+	nameTestTwo     = "test/two"
+	nameReleaseOne  = "release/one"
+	nameReleaseTwo  = "release/two"
+	namePriorityOne = "priority/one"
+	namePriorityTwo = "priority/two"
+
+	prefixTest     = "test/"
+	prefixRelease  = "release/"
+	prefixPriority = "priority/"
+
+	labelTestOne     = &github.Label{Name: &nameTestOne}
+	labelTestTwo     = &github.Label{Name: &nameTestTwo}
+	labelReleaseOne  = &github.Label{Name: &nameReleaseOne}
+	labelReleaseTwo  = &github.Label{Name: &nameReleaseTwo}
+	labelPriorityOne = &github.Label{Name: &namePriorityOne}
+	labelPriorityTwo = &github.Label{Name: &namePriorityTwo}
+
+	// Define the expected tests for TestCheckLabels()
+	CheckLabelsTests = []*CheckLabelsTest{
+		{
+			Name:             "all-types-match",
+			Labels:           []*github.Label{labelTestOne, labelTestTwo, labelReleaseOne, labelReleaseTwo, labelPriorityOne, labelPriorityTwo},
+			RequiredPrefixes: []string{prefixTest, prefixRelease, prefixPriority},
+			AnyPrefix:        false,
+			Pass:             true,
+		},
+		{
+			Name:             "simple-types-match",
+			Labels:           []*github.Label{labelTestOne},
+			RequiredPrefixes: []string{prefixTest},
+			AnyPrefix:        false,
+			Pass:             true,
+		},
+		{
+			Name:             "empty-prefixes-case",
+			Labels:           []*github.Label{labelTestOne, labelTestTwo, labelReleaseOne, labelReleaseTwo, labelPriorityOne, labelPriorityTwo},
+			RequiredPrefixes: []string{},
+			AnyPrefix:        false,
+			Pass:             true,
+		},
+		{
+			Name:             "empty-labels-case",
+			Labels:           []*github.Label{},
+			RequiredPrefixes: []string{prefixTest, prefixRelease, prefixPriority},
+			AnyPrefix:        false,
+			Pass:             false,
+		},
+		{
+			Name:             "missing-labels",
+			Labels:           []*github.Label{labelTestOne, labelTestTwo},
+			RequiredPrefixes: []string{prefixPriority},
+			AnyPrefix:        false,
+			Pass:             false,
+		},
+		{
+			Name:             "partial-missing-labels",
+			Labels:           []*github.Label{labelTestOne, labelReleaseOne, labelReleaseTwo},
+			RequiredPrefixes: []string{prefixRelease, prefixPriority},
+			AnyPrefix:        false,
+			Pass:             false,
+		},
+		{
+			Name:             "suffix-test-1",
+			Labels:           []*github.Label{labelTestOne},
+			RequiredPrefixes: []string{prefixTest},
+			AnyPrefix:        false,
+			Pass:             true,
+		},
+		{
+			Name:             "suffix-test-2",
+			Labels:           []*github.Label{labelTestTwo},
+			RequiredPrefixes: []string{prefixTest},
+			AnyPrefix:        false,
+			Pass:             true,
+		},
+	}
+)
+
+// Provide the GitLabels() function against the CheckLabelsTest type so that it
+// matches the PullRequest interface required for CheckLabels()
+func (c *CheckLabelsTest) GetLabels() []*github.Label {
+	return c.Labels
+}
+
+// Test the CheckLabels() function for testing the length of the titles on pull
+// requests in GitHub
+func TestCheckLabels(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	for _, check := range CheckLabelsTests {
+		t.Run(check.Name, func(t *testing.T) {
+			err := action.CheckLabels(logger, check, check.RequiredPrefixes, check.AnyPrefix)
+			if check.Pass {
+				assert.NoError(t, err, "The CheckLabels returned an error when nil was expected")
+			} else {
+				assert.Error(t, err, "The CheckLabels did not return an error when expected")
+			}
+		})
+	}
+}

--- a/internal/action/check_labels_test.go
+++ b/internal/action/check_labels_test.go
@@ -44,17 +44,31 @@ var (
 	// Define the expected tests for TestCheckLabels()
 	CheckLabelsTests = []*CheckLabelsTest{
 		{
-			Name:             "all-types-match",
+			Name:             "all-types-match-and",
 			Labels:           []*github.Label{labelTestOne, labelTestTwo, labelReleaseOne, labelReleaseTwo, labelPriorityOne, labelPriorityTwo},
 			RequiredPrefixes: []string{prefixTest, prefixRelease, prefixPriority},
 			AnyPrefix:        false,
 			Pass:             true,
 		},
 		{
-			Name:             "simple-types-match",
+			Name:             "all-types-match-all",
+			Labels:           []*github.Label{labelTestOne, labelTestTwo, labelReleaseOne, labelReleaseTwo, labelPriorityOne, labelPriorityTwo},
+			RequiredPrefixes: []string{prefixTest, prefixRelease, prefixPriority},
+			AnyPrefix:        true,
+			Pass:             true,
+		},
+		{
+			Name:             "simple-types-match-and",
 			Labels:           []*github.Label{labelTestOne},
 			RequiredPrefixes: []string{prefixTest},
 			AnyPrefix:        false,
+			Pass:             true,
+		},
+		{
+			Name:             "simple-types-match-any",
+			Labels:           []*github.Label{labelTestOne},
+			RequiredPrefixes: []string{prefixTest},
+			AnyPrefix:        true,
 			Pass:             true,
 		},
 		{
@@ -65,10 +79,17 @@ var (
 			Pass:             true,
 		},
 		{
-			Name:             "empty-labels-case",
+			Name:             "empty-labels-case-and",
 			Labels:           []*github.Label{},
 			RequiredPrefixes: []string{prefixTest, prefixRelease, prefixPriority},
 			AnyPrefix:        false,
+			Pass:             false,
+		},
+		{
+			Name:             "empty-labels-case-any",
+			Labels:           []*github.Label{},
+			RequiredPrefixes: []string{prefixTest, prefixRelease, prefixPriority},
+			AnyPrefix:        true,
 			Pass:             false,
 		},
 		{
@@ -79,11 +100,18 @@ var (
 			Pass:             false,
 		},
 		{
-			Name:             "partial-missing-labels",
+			Name:             "partial-missing-labels-and",
 			Labels:           []*github.Label{labelTestOne, labelReleaseOne, labelReleaseTwo},
 			RequiredPrefixes: []string{prefixRelease, prefixPriority},
 			AnyPrefix:        false,
 			Pass:             false,
+		},
+		{
+			Name:             "partial-missing-labels-any",
+			Labels:           []*github.Label{labelTestOne, labelReleaseOne, labelReleaseTwo},
+			RequiredPrefixes: []string{prefixRelease, prefixPriority},
+			AnyPrefix:        true,
+			Pass:             true,
 		},
 		{
 			Name:             "suffix-test-1",

--- a/internal/action/check_title.go
+++ b/internal/action/check_title.go
@@ -8,13 +8,13 @@ import (
 
 // Define an Interface which maps to the GetTitle function on the type so that
 // we can simplify the requirements of the value passed and improve testability
-type PullRequest interface {
+type PullRequestTitle interface {
 	GetTitle() string
 }
 
-// Check the Title of the pull request to validate that it is at least the
+// Check the title of the pull request to validate that it is at least the
 // minimum length required, and return an error if it is not
-func CheckTitle(log *logrus.Logger, pull PullRequest, minimum int) error {
+func CheckTitle(log *logrus.Logger, pull PullRequestTitle, minimum int) error {
 	title := pull.GetTitle()
 
 	log.

--- a/internal/action/check_title_test.go
+++ b/internal/action/check_title_test.go
@@ -13,7 +13,7 @@ import (
 // input, the test for the length, and if the CheckTitle() function should pass
 // or fail the test
 type CheckTitleTest struct {
-	Input   string
+	Title   string
 	Minimum int
 	Pass    bool
 }
@@ -21,17 +21,17 @@ type CheckTitleTest struct {
 // Define the expected tests for TestCheckTitle()
 var CheckTitleTests = []*CheckTitleTest{
 	{
-		Input:   "This is a Pull Request Title",
+		Title:   "This is a Pull Request Title",
 		Minimum: 20,
 		Pass:    true,
 	},
 	{
-		Input:   "This is a Pull Request Title",
+		Title:   "This is a Pull Request Title",
 		Minimum: 50,
 		Pass:    false,
 	},
 	{
-		Input:   "Invalid",
+		Title:   "Invalid",
 		Minimum: 20,
 		Pass:    false,
 	},
@@ -40,7 +40,7 @@ var CheckTitleTests = []*CheckTitleTest{
 // Provide the GitTitle() function against the CheckTitleTest type so that it
 // matches the PullRequest interface required for CheckTitle()
 func (c *CheckTitleTest) GetTitle() string {
-	return c.Input
+	return c.Title
 }
 
 // Test the CheckTitle() function for testing the length of the titles on pull

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/n3tuk/action-pull-requester/internal/github"
 
@@ -9,43 +10,46 @@ import (
 )
 
 type Options struct {
-	TitleMinimum int
+	TitleMinimum  int
+	LabelPrefixes string
 }
 
-func RunChecks(logger *logrus.Logger, pullRequest *github.PullRequest, options *Options) error {
+func RunChecks(logger *logrus.Logger, pull *github.PullRequest, options *Options) error {
 	logger.
 		WithFields(logrus.Fields{
-			"owner":      pullRequest.Owner,
-			"repository": pullRequest.Repository,
-			"number":     pullRequest.Number,
+			"owner":      pull.Owner,
+			"repository": pull.Repository,
+			"number":     pull.Number,
 		}).
 		Debug("running checks")
 
-	if err := CheckTitle(logger, pullRequest, options.TitleMinimum); err != nil {
+	if err := CheckTitle(logger, pull, options.TitleMinimum); err != nil {
 		return fmt.Errorf("check on title failed: %w", err)
 	}
 
-	if err := CheckDescription(logger, pullRequest); err != nil {
+	if err := CheckDescription(logger, pull); err != nil {
 		return fmt.Errorf("check on description failed: %w", err)
 	}
 
-	if err := CheckLabels(logger, pullRequest); err != nil {
+	prefixes := strings.Split(options.LabelPrefixes, ",")
+
+	if err := CheckLabels(logger, pull, prefixes); err != nil {
 		return fmt.Errorf("check on labels failed: %w", err)
 	}
 
 	return nil
 }
 
-func RunAutomations(logger *logrus.Logger, pullRequest *github.PullRequest) error {
+func RunAutomations(logger *logrus.Logger, pull *github.PullRequest) error {
 	logger.
 		WithFields(logrus.Fields{
-			"owner":      pullRequest.Owner,
-			"repository": pullRequest.Repository,
-			"number":     pullRequest.Number,
+			"owner":      pull.Owner,
+			"repository": pull.Repository,
+			"number":     pull.Number,
 		}).
 		Debug("running automations")
 
-	if err := CheckAssignee(logger, pullRequest); err != nil {
+	if err := CheckAssignee(logger, pull); err != nil {
 		return fmt.Errorf("check on assignee failed: %w", err)
 	}
 
@@ -58,16 +62,6 @@ func CheckDescription(log *logrus.Logger, pullRequest *github.PullRequest) error
 
 	log.
 		Error("description check not yet supported")
-
-	return nil
-}
-
-func CheckLabels(log *logrus.Logger, pullRequest *github.PullRequest) error {
-	log.
-		Debug("checking the labels")
-
-	log.
-		Error("label check not yet supported")
 
 	return nil
 }

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -10,8 +10,9 @@ import (
 )
 
 type Options struct {
-	TitleMinimum  int
-	LabelPrefixes string
+	TitleMinimum     int
+	LabelPrefixes    string
+	LabelPrefixesAny bool
 }
 
 func RunChecks(logger *logrus.Logger, pull *github.PullRequest, options *Options) error {
@@ -33,7 +34,7 @@ func RunChecks(logger *logrus.Logger, pull *github.PullRequest, options *Options
 
 	prefixes := strings.Split(options.LabelPrefixes, ",")
 
-	if err := CheckLabels(logger, pull, prefixes); err != nil {
+	if err := CheckLabels(logger, pull, prefixes, options.LabelPrefixesAny); err != nil {
 		return fmt.Errorf("check on labels failed: %w", err)
 	}
 

--- a/internal/github/main.go
+++ b/internal/github/main.go
@@ -54,5 +54,17 @@ func NewPullRequest(logger *logrus.Logger, owner, repository string, number int)
 }
 
 func (p *PullRequest) GetTitle() string {
+	if p == nil || p.pullRequest == nil {
+		return ""
+	}
+
 	return *p.pullRequest.Title
+}
+
+func (p *PullRequest) GetLabels() []*github.Label {
+	if p == nil || p.pullRequest == nil {
+		return nil
+	}
+
+	return p.pullRequest.Labels
 }


### PR DESCRIPTION
Add support for checking pull request labels using pull-checker as part of #1.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [x] I have performed a self-review of my code and run any tests locally to check.
- [x] I have added tests that prove my changes are effective and work correctly.
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [x] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
