### PR TITLE
Fix handling of `owner/repository` to support GitHub Actions

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -44,6 +44,8 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
       run: |-
         ${{ github.action_path }}/bin/pull-requester run \
+          --repository=${{ github.repository }} \
+          --number=${{ github.event.pull_request.number }} \
           --title-minimum=${{ inputs.title-minimum }} \
           --label-prefixes=${{ inputs.label-prefixes }}
           --label-prefixes-any=${{ inputs.label-prefixes-any }}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/n3tuk/action-pull-requester/internal/action"
 	"github.com/n3tuk/action-pull-requester/internal/github"
@@ -10,7 +11,6 @@ import (
 )
 
 var (
-	owner      string
 	repository string
 	number     int
 
@@ -29,10 +29,9 @@ var (
 )
 
 func init() {
-	runCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "Only show what actions would be taken")
-	runCmd.Flags().StringVarP(&owner, "owner", "o", "n3tuk", "The owner of the repository to check")
-	runCmd.Flags().StringVarP(&repository, "repository", "r", "action-pull-requester", "The name of the repository to check")
+	runCmd.Flags().StringVarP(&repository, "repository", "r", "n3tuk/action-pull-requester", "The name of the repository to check")
 	runCmd.Flags().IntVar(&number, "number", 0, "The number of the pull request to check")
+	runCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "Only show what actions would be taken")
 	runCmd.Flags().IntVar(&titleMinimum, "title-minimum", titleMinimum, "The minimum number of characters a title should contain")
 	runCmd.Flags().StringVar(&labelPrefixes, "label-prefixes", "", "A comma-separated list of label prefixes to check for on a pull request")
 	runCmd.Flags().BoolVar(&labelPrefixesAny, "label-prefixes-any", false, "Set that any label prefix can match to pass, rather than all")
@@ -46,7 +45,9 @@ func RunChecks(cmd *cobra.Command, args []string) error {
 		LabelPrefixesAny: labelPrefixesAny,
 	}
 
-	pr, err := github.NewPullRequest(logger, owner, repository, number)
+	repo := strings.Split(repository, "/")
+
+	pr, err := github.NewPullRequest(logger, repo[0], repo[1], number)
 	if err != nil {
 		return fmt.Errorf("failed to fetch the pull request: %w", err)
 	}


### PR DESCRIPTION
Fix the handling of `owner/repository` input as so to support the `github.repository` context which is provided for GitHub Actions in the runner (separate `owner` and `repository` values are not provided and string manipulation is not easy inside Actions).

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
