### PR TITLE
Fix the syntax error for GitHub Action command

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -47,7 +47,7 @@ runs:
           --repository=${{ github.repository }} \
           --number=${{ github.event.pull_request.number }} \
           --title-minimum=${{ inputs.title-minimum }} \
-          --label-prefixes=${{ inputs.label-prefixes }}
+          --label-prefixes=${{ inputs.label-prefixes }} \
           --label-prefixes-any=${{ inputs.label-prefixes-any }}
 
 branding:


### PR DESCRIPTION
Fix the syntax error for the GitHub Action command calling `pull-requester` as it is missing the line wrap token.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
