### PR TITLE
Update `--label-prefixes-any` flag for prefixes check to `--label-prefix-mode` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ jobs:
 
 ## Inputs
 
-| Name                 | Description                                                             | Required | Type     | Default |
-| :------------------- | :---------------------------------------------------------------------- | :------: | :------- | :------ |
-| `title-minimum`      | The minimum number of characters that a title should contain            | `false`  | `int`    | `25`    |
-| `label-prefixes`     | A comma-separated list of label prefixes to check for on a pull request | `false`  | `string` | `''`    |
-| `label-prefixes-any` | Set that any label prefix can match to pass, rather than all            | `false`  | `bool`   | `false' |
+| Name                | Description                                                             | Required | Type     | Default |
+| :------------------ | :---------------------------------------------------------------------- | :------: | :------- | :------ |
+| `title-minimum`     | The minimum number of characters that a title should contain            | `false`  | `int`    | `25`    |
+| `label-prefixes`    | A comma-separated list of label prefixes to check for on a pull request | `false`  | `string` | `''`    |
+| `label-prefix-mode` | Set if `any` one prefix, or `all` label prefixes, must match to pass    | `false`  | `string` | `all'   |

--- a/action.yaml
+++ b/action.yaml
@@ -13,8 +13,8 @@ inputs:
     description: A comma-separated list of label prefixes to check for on a pull request
     required: false
     default: ''
-  label-prefixes-any:
-    description: Set that any label prefix can match to pass, rather than all
+  label-prefix-mode:
+    description: Set if any one prefix, or all label prefixes, must match to pass
     required: false
     default: 'false'
 
@@ -48,7 +48,7 @@ runs:
           --number=${{ github.event.pull_request.number }} \
           --title-minimum=${{ inputs.title-minimum }} \
           --label-prefixes=${{ inputs.label-prefixes }} \
-          --label-prefixes-any=${{ inputs.label-prefixes-any }}
+          --label-prefix-mode=${{ inputs.label-prefix-mode }}
 
 branding:
   icon: user-check

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,9 +16,9 @@ var (
 
 	dryRun bool
 
-	titleMinimum     int = 25
-	labelPrefixes    string
-	labelPrefixesAny bool
+	titleMinimum    int = 25
+	labelPrefixes   string
+	labelPrefixMode string = "all"
 
 	// runCmd represents the run command
 	runCmd = &cobra.Command{
@@ -34,15 +34,15 @@ func init() {
 	runCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "Only show what actions would be taken")
 	runCmd.Flags().IntVar(&titleMinimum, "title-minimum", titleMinimum, "The minimum number of characters a title should contain")
 	runCmd.Flags().StringVar(&labelPrefixes, "label-prefixes", "", "A comma-separated list of label prefixes to check for on a pull request")
-	runCmd.Flags().BoolVar(&labelPrefixesAny, "label-prefixes-any", false, "Set that any label prefix can match to pass, rather than all")
+	runCmd.Flags().StringVar(&labelPrefixMode, "label-prefix-mode", labelPrefixMode, "Set if any one prefix, or all label prefixes, must match to pass")
 	rootCmd.AddCommand(runCmd)
 }
 
 func RunChecks(cmd *cobra.Command, args []string) error {
 	options := &action.Options{
-		TitleMinimum:     titleMinimum,
-		LabelPrefixes:    labelPrefixes,
-		LabelPrefixesAny: labelPrefixesAny,
+		TitleMinimum:    titleMinimum,
+		LabelPrefixes:   labelPrefixes,
+		LabelPrefixMode: labelPrefixMode,
 	}
 
 	repo := strings.Split(repository, "/")

--- a/internal/action/check_labels.go
+++ b/internal/action/check_labels.go
@@ -16,8 +16,15 @@ type PullRequestLabels interface {
 
 // Check the labels of the pull request to validate that the prefixes requested
 // have been attached, and return an error if it is not
-func CheckLabels(log *logrus.Logger, pull PullRequestLabels, prefixes []string, any bool) error {
+func CheckLabels(log *logrus.Logger, pull PullRequestLabels, prefixes []string, mode string) error {
 	var attached, missing []string
+
+	switch mode {
+	case "any":
+	case "all":
+	default:
+		return fmt.Errorf("the mode (%s) is not one of any or all", mode)
+	}
 
 	labels := pull.GetLabels()
 	for _, label := range labels {
@@ -28,6 +35,7 @@ func CheckLabels(log *logrus.Logger, pull PullRequestLabels, prefixes []string, 
 		WithFields(logrus.Fields{
 			"attached": strings.Join(attached, ","),
 			"prefixes": strings.Join(prefixes, ","),
+			"mode":     mode,
 		}).
 		Debug("checking the labels")
 
@@ -42,7 +50,7 @@ func CheckLabels(log *logrus.Logger, pull PullRequestLabels, prefixes []string, 
 
 		for _, label := range attached {
 			if strings.HasPrefix(label, prefix) {
-				if any {
+				if mode == "any" {
 					return nil // quick exit
 				}
 

--- a/internal/action/check_labels_test.go
+++ b/internal/action/check_labels_test.go
@@ -17,7 +17,7 @@ type CheckLabelsTest struct {
 	Name             string
 	Labels           []*github.Label
 	RequiredPrefixes []string
-	AnyPrefix        bool
+	Mode             string
 	Pass             bool
 }
 
@@ -47,85 +47,92 @@ var (
 			Name:             "all-types-match-and",
 			Labels:           []*github.Label{labelTestOne, labelTestTwo, labelReleaseOne, labelReleaseTwo, labelPriorityOne, labelPriorityTwo},
 			RequiredPrefixes: []string{prefixTest, prefixRelease, prefixPriority},
-			AnyPrefix:        false,
+			Mode:             "all",
 			Pass:             true,
 		},
 		{
 			Name:             "all-types-match-all",
 			Labels:           []*github.Label{labelTestOne, labelTestTwo, labelReleaseOne, labelReleaseTwo, labelPriorityOne, labelPriorityTwo},
 			RequiredPrefixes: []string{prefixTest, prefixRelease, prefixPriority},
-			AnyPrefix:        true,
+			Mode:             "all",
 			Pass:             true,
 		},
 		{
 			Name:             "simple-types-match-and",
 			Labels:           []*github.Label{labelTestOne},
 			RequiredPrefixes: []string{prefixTest},
-			AnyPrefix:        false,
+			Mode:             "all",
 			Pass:             true,
 		},
 		{
 			Name:             "simple-types-match-any",
 			Labels:           []*github.Label{labelTestOne},
 			RequiredPrefixes: []string{prefixTest},
-			AnyPrefix:        true,
+			Mode:             "all",
 			Pass:             true,
 		},
 		{
 			Name:             "empty-prefixes-case",
 			Labels:           []*github.Label{labelTestOne, labelTestTwo, labelReleaseOne, labelReleaseTwo, labelPriorityOne, labelPriorityTwo},
 			RequiredPrefixes: []string{},
-			AnyPrefix:        false,
+			Mode:             "all",
 			Pass:             true,
 		},
 		{
 			Name:             "empty-labels-case-and",
 			Labels:           []*github.Label{},
 			RequiredPrefixes: []string{prefixTest, prefixRelease, prefixPriority},
-			AnyPrefix:        false,
+			Mode:             "all",
 			Pass:             false,
 		},
 		{
 			Name:             "empty-labels-case-any",
 			Labels:           []*github.Label{},
 			RequiredPrefixes: []string{prefixTest, prefixRelease, prefixPriority},
-			AnyPrefix:        true,
+			Mode:             "any",
 			Pass:             false,
 		},
 		{
 			Name:             "missing-labels",
 			Labels:           []*github.Label{labelTestOne, labelTestTwo},
 			RequiredPrefixes: []string{prefixPriority},
-			AnyPrefix:        false,
+			Mode:             "all",
 			Pass:             false,
 		},
 		{
 			Name:             "partial-missing-labels-and",
 			Labels:           []*github.Label{labelTestOne, labelReleaseOne, labelReleaseTwo},
 			RequiredPrefixes: []string{prefixRelease, prefixPriority},
-			AnyPrefix:        false,
+			Mode:             "all",
 			Pass:             false,
 		},
 		{
 			Name:             "partial-missing-labels-any",
 			Labels:           []*github.Label{labelTestOne, labelReleaseOne, labelReleaseTwo},
 			RequiredPrefixes: []string{prefixRelease, prefixPriority},
-			AnyPrefix:        true,
+			Mode:             "any",
 			Pass:             true,
 		},
 		{
 			Name:             "suffix-test-1",
 			Labels:           []*github.Label{labelTestOne},
 			RequiredPrefixes: []string{prefixTest},
-			AnyPrefix:        false,
+			Mode:             "all",
 			Pass:             true,
 		},
 		{
 			Name:             "suffix-test-2",
 			Labels:           []*github.Label{labelTestTwo},
 			RequiredPrefixes: []string{prefixTest},
-			AnyPrefix:        false,
+			Mode:             "all",
 			Pass:             true,
+		},
+		{
+			Name:             "invalid-mode",
+			Labels:           []*github.Label{labelTestTwo},
+			RequiredPrefixes: []string{prefixTest},
+			Mode:             "everything",
+			Pass:             false,
 		},
 	}
 )
@@ -143,7 +150,7 @@ func TestCheckLabels(t *testing.T) {
 
 	for _, check := range CheckLabelsTests {
 		t.Run(check.Name, func(t *testing.T) {
-			err := action.CheckLabels(logger, check, check.RequiredPrefixes, check.AnyPrefix)
+			err := action.CheckLabels(logger, check, check.RequiredPrefixes, check.Mode)
 			if check.Pass {
 				assert.NoError(t, err, "The CheckLabels returned an error when nil was expected")
 			} else {

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -10,9 +10,9 @@ import (
 )
 
 type Options struct {
-	TitleMinimum     int
-	LabelPrefixes    string
-	LabelPrefixesAny bool
+	TitleMinimum    int
+	LabelPrefixes   string
+	LabelPrefixMode string
 }
 
 func RunChecks(logger *logrus.Logger, pull *github.PullRequest, options *Options) error {
@@ -34,7 +34,7 @@ func RunChecks(logger *logrus.Logger, pull *github.PullRequest, options *Options
 
 	prefixes := strings.Split(options.LabelPrefixes, ",")
 
-	if err := CheckLabels(logger, pull, prefixes, options.LabelPrefixesAny); err != nil {
+	if err := CheckLabels(logger, pull, prefixes, options.LabelPrefixMode); err != nil {
 		return fmt.Errorf("check on labels failed: %w", err)
 	}
 


### PR DESCRIPTION
Update the `--label-prefixes-any` flag for the application to `--label-prefix-mode` with an argument to allow selection between `any` and `all`. This should make it easier to use and configure, and to expand upon in the future, if required.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [x] I have performed a self-review of my code and run any tests locally to check.
- [x] I have added tests that prove my changes are effective and work correctly.
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
