### PR TITLE
 Add support for checking pull request bodies

### DIFF
--- a/.github/workflows/pull-requester.yaml
+++ b/.github/workflows/pull-requester.yaml
@@ -37,5 +37,3 @@ jobs:
         # Target main here as it's easier than trying to deal with future
         # versions that this pull request will become
         uses: n3tuk/action-pull-requester@v1
-        with:
-          label-prefixes: release/,type/,update/

--- a/README.md
+++ b/README.md
@@ -66,8 +66,10 @@ jobs:
 
 ## Inputs
 
-| Name                | Description                                                             | Required | Type     | Default |
-| :------------------ | :---------------------------------------------------------------------- | :------: | :------- | :------ |
-| `title-minimum`     | The minimum number of characters that a title should contain            | `false`  | `int`    | `25`    |
-| `label-prefixes`    | A comma-separated list of label prefixes to check for on a pull request | `false`  | `string` | `''`    |
-| `label-prefix-mode` | Set if `any` one prefix, or `all` label prefixes, must match to pass    | `false`  | `string` | `all'   |
+| Name                | Description                                                              | Required | Type     | Default |
+| :------------------ | :----------------------------------------------------------------------- | :------: | :------- | :------ |
+| `title-minimum`     | The minimum number of characters that the title should contain           | `false`  | `int`    | `25`    |
+| `body-split`        | The set of characters which split the body and the pull request template | `false`  | `string` | `---`   |
+| `body-minimum`      | The minimum number of characters that the body should contain            | `false`  | `int`    | `100`   |
+| `label-prefixes`    | A comma-separated list of label prefixes to check for on a pull request  | `false`  | `string` | `''`    |
+| `label-prefix-mode` | Set if `any` one prefix, or `all` label prefixes, must match to pass     | `false`  | `string` | `all`   |

--- a/action.yaml
+++ b/action.yaml
@@ -6,9 +6,17 @@ description: |-
 
 inputs:
   title-minimum:
-    description: The minimum number of characters that a title should contain
+    description: The minimum number of characters that the title should contain
     required: false
     default: '25'
+  body-split:
+    description: The set of characters which split the body and the pull request template
+    required: false
+    default: '---'
+  body-minimum:
+    description: The minimum number of characters that the body should contain
+    required: false
+    default: '100'
   label-prefixes:
     description: A comma-separated list of label prefixes to check for on a pull request
     required: false
@@ -47,6 +55,8 @@ runs:
           --repository=${{ github.repository }} \
           --number=${{ github.event.pull_request.number }} \
           --title-minimum=${{ inputs.title-minimum }} \
+          --body-split=${{ inputs.body-split }} \
+          --body-minimum=${{ inputs.body-minimum }} \
           --label-prefixes=${{ inputs.label-prefixes }} \
           --label-prefix-mode=${{ inputs.label-prefix-mode }}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -19,7 +19,7 @@ var (
 	titleMinimum    int    = 25
 	bodySplit       string = "## Checklist"
 	bodyMinimum     int    = 100
-	labelPrefixes   string
+	labelPrefixes   string = strings.Join([]string{"release/", "type/", "update/"}, ",")
 	labelPrefixMode string = "all"
 
 	// runCmd represents the run command

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,7 +16,9 @@ var (
 
 	dryRun bool
 
-	titleMinimum    int = 25
+	titleMinimum    int    = 25
+	bodySplit       string = "## Checklist"
+	bodyMinimum     int    = 100
 	labelPrefixes   string
 	labelPrefixMode string = "all"
 
@@ -32,7 +34,9 @@ func init() {
 	runCmd.Flags().StringVarP(&repository, "repository", "r", "n3tuk/action-pull-requester", "The name of the repository to check")
 	runCmd.Flags().IntVar(&number, "number", 0, "The number of the pull request to check")
 	runCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "Only show what actions would be taken")
-	runCmd.Flags().IntVar(&titleMinimum, "title-minimum", titleMinimum, "The minimum number of characters a title should contain")
+	runCmd.Flags().IntVar(&titleMinimum, "title-minimum", titleMinimum, "The minimum number of characters the title should contain")
+	runCmd.Flags().StringVar(&bodySplit, "body-split", bodySplit, "The set of characters which split the body and the pull request template")
+	runCmd.Flags().IntVar(&bodyMinimum, "body-minimum", bodyMinimum, "The minimum number of characters the body should contain")
 	runCmd.Flags().StringVar(&labelPrefixes, "label-prefixes", "", "A comma-separated list of label prefixes to check for on a pull request")
 	runCmd.Flags().StringVar(&labelPrefixMode, "label-prefix-mode", labelPrefixMode, "Set if any one prefix, or all label prefixes, must match to pass")
 	rootCmd.AddCommand(runCmd)
@@ -41,6 +45,8 @@ func init() {
 func RunChecks(cmd *cobra.Command, args []string) error {
 	options := &action.Options{
 		TitleMinimum:    titleMinimum,
+		BodySplit:       bodySplit,
+		BodyMinimum:     bodyMinimum,
 		LabelPrefixes:   labelPrefixes,
 		LabelPrefixMode: labelPrefixMode,
 	}

--- a/internal/action/check_description.go
+++ b/internal/action/check_description.go
@@ -1,0 +1,43 @@
+package action
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Define an Interface which maps to the GetBody function on the type so that we
+// can simplify the requirements of the value passed and improve testability
+type PullRequestBody interface {
+	GetBody() string
+}
+
+// Check the body of the pull request to validate that it is at least the
+// minimum length required, and return an error if it is not
+func CheckBody(log *logrus.Logger, pull PullRequestBody, split string, minimum int) error {
+	body := pull.GetBody()
+	check := body
+
+	log.
+		WithFields(logrus.Fields{
+			"body":    body,
+			"minimum": minimum,
+			"split":   split,
+		}).
+		Debug("check the body")
+
+	if split != "" {
+		splits := strings.Split(body, split)
+		check = splits[0]
+	}
+
+	if len(check) < minimum {
+		return fmt.Errorf("the body of the pull request has less than %d characters", minimum)
+	}
+
+	log.
+		Info("the pull request body check has passed")
+
+	return nil
+}

--- a/internal/action/check_description_test.go
+++ b/internal/action/check_description_test.go
@@ -1,0 +1,132 @@
+package action_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/n3tuk/action-pull-requester/internal/action"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+// Define the structure of the table for TestCheckBody, with the expected
+// input, the test for the length, and if the CheckBody() function should pass
+// or fail the test
+type CheckBodyTest struct {
+	Name    string
+	Body    string
+	Split   string
+	Minimum int
+	Pass    bool
+}
+
+// Define the expected tests for TestCheckBody()
+var CheckBodyTests = []*CheckBodyTest{
+	{
+		Name: "test-simple-body",
+		Body: strings.Join([]string{
+			"This is the body text for the pull request.",
+		}, "\n"),
+		Split:   "---",
+		Minimum: 35,
+		Pass:    true,
+	},
+	{
+		Name: "test-split-body-pass",
+		Body: strings.Join([]string{
+			"This is the body text for the pull request.",
+			"",
+			"---",
+			"",
+			"This is the footer to not be counted",
+		}, "\n"),
+		Split:   "---",
+		Minimum: 35,
+		Pass:    true,
+	},
+	{
+		Name: "test-split-body-fail",
+		Body: strings.Join([]string{
+			"This is the body text for the pull request.",
+			"",
+			"---",
+			"",
+			"This is the footer to not be counted",
+		}, "\n"),
+		Split:   "---",
+		Minimum: 60,
+		Pass:    false,
+	},
+	{
+		Name: "test-split-no-split",
+		Body: strings.Join([]string{
+			"This is the body text for the pull request.",
+			"",
+			"---",
+			"",
+			"This is the footer to not be counted",
+		}, "\n"),
+		Split:   "",
+		Minimum: 60,
+		Pass:    true,
+	},
+	{
+		Name: "test-split-without-split",
+		Body: strings.Join([]string{
+			"This is the body text for the pull request.",
+			"",
+			"This is the footer to not be counted",
+		}, "\n"),
+		Split:   "---",
+		Minimum: 60,
+		Pass:    true,
+	},
+	{
+		Name: "test-slim-split",
+		Body: strings.Join([]string{
+			"This is the body text for the pull request.",
+			"---",
+			"This is the footer to not be counted",
+		}, "\n"),
+		Split:   "---",
+		Minimum: 35,
+		Pass:    true,
+	},
+	{
+		Name: "test-alternate-split",
+		Body: strings.Join([]string{
+			"This is the body text for the pull request.",
+			"",
+			"## Checklist",
+			"",
+			"- [ ] check or not",
+		}, "\n"),
+		Split:   "---",
+		Minimum: 35,
+		Pass:    true,
+	},
+}
+
+// Provide the GitBody() function against the CheckBodyTest type so that it
+// matches the PullRequest interface required for CheckBody()
+func (c *CheckBodyTest) GetBody() string {
+	return c.Body
+}
+
+// Test the CheckBody() function for testing the length of the bodys on pull
+// requests in GitHub
+func TestCheckBody(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	for _, check := range CheckBodyTests {
+		t.Run(check.Name, func(t *testing.T) {
+			err := action.CheckBody(logger, check, check.Split, check.Minimum)
+			if check.Pass {
+				assert.NoError(t, err, "The CheckBody returned an error when nil was expected")
+			} else {
+				assert.Error(t, err, "The CheckBody did not return an error when expected")
+			}
+		})
+	}
+}

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -13,6 +13,7 @@ type (
 	PullRequest interface {
 		PullRequestTitle
 		PullRequestLabels
+		PullRequestBody
 
 		GetOwner() string
 		GetRepository() string
@@ -41,8 +42,8 @@ func RunChecks(logger *logrus.Logger, pull PullRequest, options *Options) error 
 		return fmt.Errorf("check on title failed: %w", err)
 	}
 
-	if err := CheckDescription(logger, pull); err != nil {
-		return fmt.Errorf("check on description failed: %w", err)
+	if err := CheckBody(logger, pull, options.BodySplit, options.BodyMinimum); err != nil {
+		return fmt.Errorf("check on body failed: %w", err)
 	}
 
 	prefixes := strings.Split(options.LabelPrefixes, ",")
@@ -66,16 +67,6 @@ func RunAutomations(logger *logrus.Logger, pull *github.PullRequest) error {
 	if err := CheckAssignee(logger, pull); err != nil {
 		return fmt.Errorf("check on assignee failed: %w", err)
 	}
-
-	return nil
-}
-
-func CheckDescription(log *logrus.Logger, pullRequest *github.PullRequest) error {
-	log.
-		Debug("checking the description")
-
-	log.
-		Error("description check not yet supported")
 
 	return nil
 }

--- a/internal/action/main.go
+++ b/internal/action/main.go
@@ -9,18 +9,31 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type Options struct {
-	TitleMinimum    int
-	LabelPrefixes   string
-	LabelPrefixMode string
-}
+type (
+	PullRequest interface {
+		PullRequestTitle
+		PullRequestLabels
 
-func RunChecks(logger *logrus.Logger, pull *github.PullRequest, options *Options) error {
+		GetOwner() string
+		GetRepository() string
+		GetNumber() int
+	}
+
+	Options struct {
+		TitleMinimum    int
+		BodySplit       string
+		BodyMinimum     int
+		LabelPrefixes   string
+		LabelPrefixMode string
+	}
+)
+
+func RunChecks(logger *logrus.Logger, pull PullRequest, options *Options) error {
 	logger.
 		WithFields(logrus.Fields{
-			"owner":      pull.Owner,
-			"repository": pull.Repository,
-			"number":     pull.Number,
+			"owner":      pull.GetOwner(),
+			"repository": pull.GetRepository(),
+			"number":     pull.GetNumber(),
 		}).
 		Debug("running checks")
 

--- a/internal/github/main.go
+++ b/internal/github/main.go
@@ -53,6 +53,30 @@ func NewPullRequest(logger *logrus.Logger, owner, repository string, number int)
 	return pullRequest, nil
 }
 
+func (p *PullRequest) GetOwner() string {
+	if p == nil {
+		return ""
+	}
+
+	return p.Owner
+}
+
+func (p *PullRequest) GetRepository() string {
+	if p == nil {
+		return ""
+	}
+
+	return p.Repository
+}
+
+func (p *PullRequest) GetNumber() int {
+	if p == nil {
+		return 0
+	}
+
+	return p.Number
+}
+
 func (p *PullRequest) GetTitle() string {
 	if p == nil || p.pullRequest == nil {
 		return ""

--- a/internal/github/main.go
+++ b/internal/github/main.go
@@ -85,6 +85,14 @@ func (p *PullRequest) GetTitle() string {
 	return *p.pullRequest.Title
 }
 
+func (p *PullRequest) GetBody() string {
+	if p == nil || p.pullRequest == nil {
+		return ""
+	}
+
+	return *p.pullRequest.Body
+}
+
 func (p *PullRequest) GetLabels() []*github.Label {
 	if p == nil || p.pullRequest == nil {
 		return nil


### PR DESCRIPTION
Add the initial code to check the body of the pull request, which currently requires that it meets a minimum length once the body has been split (if the text to split on has been supplied).

Part of: #1 

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [x] I have performed a self-review of my code and run any tests locally to check.
- [x] I have added tests that prove my changes are effective and work correctly.
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [x] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
