### PR TITLE
Add missing error-based test for `CheckAssignee()`

### DIFF
--- a/internal/action/check_assignee_test.go
+++ b/internal/action/check_assignee_test.go
@@ -69,6 +69,14 @@ var (
 			GitHubError: nil,
 			Pass:        true,
 		},
+		{
+			Name:        "unassigned-with-error",
+			User:        user,
+			Assignees:   nil,
+			UserPresent: false,
+			GitHubError: fmt.Errorf("unknown error"),
+			Pass:        false,
+		},
 	}
 )
 


### PR DESCRIPTION
Add a missing error-based test for `CheckAssignee()` tests which validates the control follow when dealing with errors from GitHub in `SetAssignee().`

Reference: #1 

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [x] I have performed a self-review of my code and run any tests locally to check.
- [x] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [x] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
