### PR TITLE
Migrate CodeCov to use the `codecov-cli` tool

### DIFF
--- a/.github/workflows/go-integrations.yaml
+++ b/.github/workflows/go-integrations.yaml
@@ -80,13 +80,25 @@ jobs:
           go tool cover \
             -func=coverage.out
 
-      - name: Upload coverage reports
-        uses: codecov/codecov-action@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.out
-          flags: unit-tests
-          name: go-cover
+          python-version: 3.11
+          cache: pip
+
+      - name: Install the Python packages
+        run: pip install -r requirements.txt
+
+      - name: Upload coverage reports to Codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          codecovcli create-commit
+          codecovcli create-report
+          codecovcli do-upload \
+            --file coverage.out \
+            --name go-cover \
+            --flag unit-tests
 
   linting:
     name: golangci Linting

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -40,7 +40,7 @@ tasks:
       - go mod download
 
   healthcheck:
-    desc: Check that the GoReleaser environtment is valid
+    desc: Check that the GoReleaser environment is valid
     run: once
     internal: true
     sources:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+codecov-cli==0.1.13


### PR DESCRIPTION
Migrate the CodeCov configuration from using the standard GitHub Action, but the new Python-based `codecov-cli` tool.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [ ] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
