### PR TITLE
Improve handling of Mergify rules with commits and labels

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -9,11 +9,14 @@ pull_request_rules:
 
   # If the pull request was raised by Dependabot, and only Dependabot or GitHub
   # Actions have make changes to the branch, then automatically approve if it's
-  # not in conflict with the base branch.
+  # not in conflict with the base branch, and not closed.
   - name: Automatic approval for Dependabot pull requests
     conditions:
       - "author=dependabot[bot]"
+      - "base=main"
+      - "#commits-behind=0"
       - "-conflict"
+      - "-closed"
       - or:
           - "commits[*].author==dependabot[bot]"
           - "commits[*].author==github-actions[bot]"
@@ -22,51 +25,62 @@ pull_request_rules:
         type: APPROVE
 
   # If a commit other than the initial commit is added to a pull request raised
-  # by Dependabot, and that commit author is GitHub Actions, and the commit
-  # title starts with the word Syncing, then add the force-ci-run label to
-  # trigger the GitHub Workflows for this commit
+  # by Dependabot, and that commit author is GitHub Actions, and the last
+  # synchronised commit title starts with the word Syncing, then add the
+  # force-ci-run label to trigger the GitHub Workflows for this commit
   - name: Trigger force-ci-run on GitHub Actions commits
     conditions:
-      - author=dependabot[bot]
+      - "author=dependabot[bot]"
+      - "base=main"
       - "#commits>1"
       - "commits[-1].author=github-actions[bot]"
-      - "commits[-1].commit_message=~^Syncing"
+      - "commits[-1].commit_message~=^Syncing"
+      - "#commits-behind=0"
+      - "-label=force-ci-run"
       - "-conflict"
+      - "-closed"
+      - not:
+          or:
+            - check-neutral~=^Remove Label
+            - check-pending~=^Remove Label
+            - check-success~=^Remove Label
     actions:
       label:
         add:
-          - force-ci-run
+          - "force-ci-run"
 
   # If the pull request was raised by Dependabot, it only has a linear history,
   # it has been approved for merging into the main or master branches, and is
-  # neither in conflict with the main branch, nor the force-ci-run label is still
-  # present, then automatically merge this request.
+  # neither in conflict with the main branch, fallen behind, nor the
+  # force-ci-run label is still present, then automatically merge this request.
   - name: Automatic merge for Dependabot pull requests
     conditions:
-      - and:
-          - author=dependabot[bot]
-          - linear-history
-          - "#approved-reviews-by>=1"
-          - "-conflict"
-          - "-label=force-ci-run"
-      - or:
-          - base=main
-          - base=master
+      - "author=dependabot[bot]"
+      - "base=main"
+      - "linear-history"
+      - "#approved-reviews-by>=1"
+      - "-label=force-ci-run"
+      - "-conflict"
+      - "-closed"
     actions:
       merge:
         method: rebase
 
-  # If there is a conflict between this pull request and the default branch, then
-  # add a message for Dependabot to recreate the pull request. This should be
-  # recreate rather than rebase as there may be none-dependabot changes added as
-  # commits to the branch for documentation changes.
+  # If there is a conflict between this pull request and the default branch, or
+  # this pull request has failed behind the default branch due to other pull
+  # requests being merged before it, then add a message for Dependabot to
+  # recreate the pull request. This should be recreate rather than rebase as
+  # there may be non-dependabot changes added as commits to the branch for
+  # documentation changes. Although these non-dependabot changes will be lost,
+  # they should be re-created nonetheless.
   - name: Trigger Dependabot to recreate on merge conflict
     conditions:
-      - author=dependabot[bot]
-      - conflict
+      - "author=dependabot[bot]"
+      - "base=main"
+      - "-closed"
       - or:
-          - base=main
-          - base=master
+          - "conflict"
+          - "#commits-behind>0"
     actions:
       comment:
         message: "@dependabot recreate"


### PR DESCRIPTION
Improve the handling of Mergify rules to prevent looping with the `force-ci-run` (Mergify will add the `force-ci-run` label before GitHub Actions can complete the checks and allow the merge to be approved, so check that "Remove Label" job has been run too), and ensure approvals and recreation are handled based on their relative position to the target branch too.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [ ] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
